### PR TITLE
fix external library loading on OpenBSD

### DIFF
--- a/libssh2/libssh2-cffi.lisp
+++ b/libssh2/libssh2-cffi.lisp
@@ -15,6 +15,7 @@
 
 (define-foreign-library libssh2
   (:darwin "libssh2.dylib")
+  (:openbsd "libssh2.so")
   (:unix  "libssh2.so.1")
   (:win32 "libssh2-1.dll")
   (t (:default "libssh2")))


### PR DESCRIPTION
OpenBSD ports use its own versioning for shared objects. Each ported software
with shared objects use internal OpenBSD version. For example if program compile
"libfoo.so.4" normally, once the first version of it is ported to OpenBSD it
gets patched to use its own version with major.minor suffix starting from
0.0. So the above library would become "libfoo.so.0.0". This internal OpenBSD
version then lives life of its own and gets bumped when OpenBSD or the program
itself is changed.  To use specific library version on OpenBSD is a bit
difficult as the major.minor versions might change multiple times between
OpenBSD releases.

To aid this, OpenBSD linker can load either specific versions or it can
automatically find the latest version. If OpenBSD linker is given library
without version, such as "libfoo.so" it then looks for latest version that it
can find and loads it. Thats the usually the desired outcome.
This commit makes OpenBSD load the latest version by default.